### PR TITLE
Add opt-in npmscan.com MCP server integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,9 +189,14 @@ programs.cursor = {
     
     # Browser automation
     playwright.enable = true;
+    
+    # npm package security scanning (opt-in, remote, no auth)
+    npmscan.enable = true;
   };
 };
 ```
+
+See [docs/MCP_NPMSCAN_SETUP.md](docs/MCP_NPMSCAN_SETUP.md) for available npmscan tools.
 
 ### Cursor Studio Module
 

--- a/docs/MCP_NPMSCAN_SETUP.md
+++ b/docs/MCP_NPMSCAN_SETUP.md
@@ -1,0 +1,97 @@
+# npmscan MCP Server Setup
+
+> **Purpose**: Let the AI agent inside Cursor check npm packages for malware, crypto-drainers, and known vulnerabilities before you install them.
+
+## Overview
+
+[npmscan.com](https://npmscan.com/) is a free, third-party malware detection service for the npm ecosystem, backed by a threat intelligence database (47K+ known threats, 2.5M+ scanned packages) and OSV.dev / GitHub Security Advisories for CVE data. It runs a public **MCP server** at `https://npmscan.com/api/mcp` — no account, no API key, nothing to configure.
+
+Unlike every other MCP server in this repo, npmscan is **remote**: Cursor talks to it over HTTP instead of launching a local process. There's no npm package to install and no secret to manage.
+
+This is agent-facing security research only — it does not scan or block anything automatically. It complements, but does not replace, the offline blocklist enforced by Cursor Studio's `SecurityScanner` (see [docs/internal/NPM_SECURITY_ARCHITECTURE.md](internal/NPM_SECURITY_ARCHITECTURE.md)).
+
+## Setup
+
+Enable it in your Home Manager config:
+
+```nix
+programs.cursor = {
+  enable = true;
+  mcp = {
+    enable = true;
+    npmscan.enable = true;
+  };
+};
+```
+
+Rebuild/activate your Home Manager generation, then **fully restart Cursor** (not just reload window) so it picks up the new `~/.cursor/mcp.json` entry:
+
+```json
+{
+  "mcpServers": {
+    "npmscan": {
+      "type": "http",
+      "url": "https://npmscan.com/api/mcp"
+    }
+  }
+}
+```
+
+It's opt-in and defaults to off, since it's an external network service — enable it explicitly like `github`/`playwright`.
+
+## Verify
+
+Ask the agent:
+```
+"Use npmscan to check if event-stream@3.3.6 has any known issues"
+```
+
+If it calls an npmscan tool and returns a real result (rather than saying it has no such tool), you're set.
+
+## Available Tools
+
+| Tool | What it does |
+|------|---------------|
+| `search_packages` | Find npm packages by name or keyword |
+| `get_package` | Latest version, maintainers, license, install scripts, publish history |
+| `get_package_version` | Metadata for one pinned version (e.g. install scripts before you install it) |
+| `query_vulnerabilities` | OSV.dev lookup for known vulnerabilities in a package (+ optional version) |
+| `batch_query_vulnerabilities` | Same as above, up to 100 packages at once — good for scanning a whole `package.json` |
+| `get_latest_advisories` | Reviewed GitHub Security Advisories, filterable by severity/category/CVE/GHSA ID |
+
+Every result includes an `npmscanUrl` linking to a human-readable write-up on npmscan.com.
+
+## Example Prompts
+
+- "Before adding `left-pad` to package.json, check npmscan for known issues."
+- "Batch-check all my dependencies in package.json against npmscan for vulnerabilities."
+- "What are the latest critical npm security advisories?"
+- "Does `event-stream` have any install scripts I should know about before I install version 3.3.6?"
+
+## Rate Limits & Trust
+
+- **No authentication** — public and free.
+- **~30 requests/minute per IP** — the agent may occasionally hit this if you ask it to batch-check many packages back to back; it's a third-party service you don't control, so treat results as advisory, not a hard gate.
+- Since it's unauthenticated and read-only, there's no token to rotate or leak — the only thing to weigh before enabling is that queries (package names you're curious about) are sent to a third party.
+
+## Troubleshooting
+
+### Agent says it has no npmscan tool
+- Confirm `programs.cursor.mcp.npmscan.enable = true;` was applied and Cursor was **fully restarted**.
+- Check `~/.cursor/mcp.json` contains the `npmscan` entry shown above.
+- Check Cursor logs: View → Output → select "MCP" from the dropdown.
+
+### Requests time out or get rate-limited
+- You're likely over the ~30 req/min limit (e.g. asked for a large batch scan repeatedly). Wait a minute and retry, or scope the query to fewer packages.
+
+## Self-Hosting / Override
+
+If npmscan ever offers a private/self-hosted instance, or the endpoint changes, override the URL:
+
+```nix
+programs.cursor.mcp.npmscan.url = "https://your-instance.example.com/api/mcp";
+```
+
+---
+
+*Last updated: 2026-08-10*

--- a/docs/internal/NPM_SECURITY_ARCHITECTURE.md
+++ b/docs/internal/NPM_SECURITY_ARCHITECTURE.md
@@ -111,7 +111,13 @@ The **Shai-Hulud** supply chain attack campaign (November 2025) has demonstrated
 **Goal**: Detect malicious packages before they can execute
 
 1. **Integrate with security scanners**
-   - NPMScan API for real-time malware detection
+   - ✅ NPMScan MCP server — agent-facing only (2026-08-10). The AI assistant can query
+     `search_packages`, `get_package`, `query_vulnerabilities`, `batch_query_vulnerabilities`,
+     and `get_latest_advisories` mid-conversation via `programs.cursor.mcp.npmscan.enable`.
+     See [docs/MCP_NPMSCAN_SETUP.md](../MCP_NPMSCAN_SETUP.md). This is opt-in, advisory, and
+     conversational — it does **not** run automatically before `npm install`, and does **not**
+     feed into Cursor Studio's `SecurityScanner`/blocklist (`cursor-studio-egui/src/security.rs`).
+     The actual pre-install pipeline scan described below is still unimplemented.
    - Socket.dev for supply chain analysis
    - Snyk for vulnerability scanning
 
@@ -475,6 +481,7 @@ mcp.security = {
 | Date | Change |
 |------|--------|
 | 2025-11-27 | Initial architecture document |
+| 2026-08-10 | Added npmscan.com MCP server integration (agent-facing, opt-in) |
 
 ---
 

--- a/examples/with-mcp/README.md
+++ b/examples/with-mcp/README.md
@@ -10,6 +10,7 @@ Cursor with all MCP servers enabled - the full AI-powered experience.
 - **nixos** MCP - Package/option search
 - **github** MCP - Repository operations
 - **playwright** MCP - Browser automation
+- **npmscan** MCP - npm package security scanning (remote, no auth)
 
 **Note:** You may need to disable a few of the tools you are not using per server, as well as ensure the built in cursor browser (currently broken, unknown if fixable for NixOS) is disabled. These are not the only mcp servers that work on NixOS, but these are the only ones I really use in my workflow.
 
@@ -69,6 +70,13 @@ mcp_github_search_code({ query: "..." })
 mcp_playwright_browser_navigate({ url: "https://example.com" })
 mcp_playwright_browser_snapshot()
 mcp_playwright_browser_take_screenshot({ filename: "test.png" })
+```
+
+**npm Package Security** (see [docs/MCP_NPMSCAN_SETUP.md](../../docs/MCP_NPMSCAN_SETUP.md)):
+
+```typescript
+mcp_npmscan_query_vulnerabilities({ name: "lodash", version: "4.17.15" })
+mcp_npmscan_batch_query_vulnerabilities({ packages: [...] })
 ```
 
 ## Configuration Options

--- a/examples/with-mcp/flake.nix
+++ b/examples/with-mcp/flake.nix
@@ -68,6 +68,8 @@
                 browserPackage = pkgs.chromium;
                 headless = false;
               };
+
+              npmscan.enable = true; # npm package security scanning (remote, no auth)
             };
           };
         })

--- a/home-manager-module/default.nix
+++ b/home-manager-module/default.nix
@@ -187,6 +187,14 @@ let
         };
       })
 
+      # npmscan MCP Server (remote HTTP, npm package security scanning)
+      (mkIf (cfg.mcp.enable && cfg.mcp.npmscan.enable) {
+        npmscan = {
+          type = "http";
+          url = cfg.mcp.npmscan.url;
+        };
+      })
+
       # Playwright MCP Server (browser automation)
       (mkIf (cfg.mcp.enable && cfg.mcp.playwright.enable) (
         let
@@ -348,6 +356,22 @@ in
 
             Required token permissions: repo, read:org
             Create at: https://github.com/settings/tokens
+          '';
+        };
+      };
+
+      npmscan = {
+        enable = mkEnableOption "npmscan.com MCP server for npm package security scanning (remote, no auth)";
+
+        url = mkOption {
+          type = types.str;
+          default = "https://npmscan.com/api/mcp";
+          description = ''
+            npmscan MCP server endpoint. Public, unauthenticated, rate-limited
+            to ~30 requests/minute per IP. Override only if self-hosting or
+            using a private instance.
+
+            See docs/MCP_NPMSCAN_SETUP.md for available tools.
           '';
         };
       };


### PR DESCRIPTION
Registers npmscan's free, unauthenticated, remote MCP server (https://npmscan.com/api/mcp) as a new programs.cursor.mcp.npmscan option, giving the AI agent tools to check npm packages for malware, crypto-drainers, and known vulnerabilities before install. Defaults to off, matching the github/playwright precedent for external network services. Verified live against the server (initialize, tools/list, and a real query_vulnerabilities call) before committing.